### PR TITLE
Fix ascii' codec can't decode byte MUWM-4426

### DIFF
--- a/rc_django/cache_implementation/memcache.py
+++ b/rc_django/cache_implementation/memcache.py
@@ -32,7 +32,7 @@ class MemcachedCache(object):
         if not data:
             return None
 
-        values = pickle.loads(data)
+        values = pickle.loads(data, encoding="utf8")
         response = MockHTTP()
         response.headers = values["headers"]
         response.status = values["status"]
@@ -53,7 +53,7 @@ class MemcachedCache(object):
         try:
             value = self.client.get(key)
             if value:
-                data = pickle.loads(value)
+                data = pickle.loads(value, encoding="utf8")
                 if "time_stamp" in data:
                     cached_data_dt = parse(data["time_stamp"])
                     if new_data_dt > cached_data_dt:


### PR DESCRIPTION
https://stackoverflow.com/questions/46001958/typeerror-a-bytes-like-object-is-required-not-str-when-opening-python-2-pick/47814305#47814305

The original error no longer occurs as the python 2.7 writes in cache being cleared.  However having the encoding specified is safer.